### PR TITLE
fix:product 카테고리별 페이지 보더 삭제 및 사이즈 조정

### DIFF
--- a/src/components/ui/ListCard.tsx
+++ b/src/components/ui/ListCard.tsx
@@ -54,7 +54,10 @@ const ListCard = ({ product }: ListCardProps) => {
     } catch (error) {
       if (error instanceof AxiosError && error.response?.status === 409) {
         showError("이미 위시리스트에 추가된 상품입니다.");
-      } else if (error instanceof AxiosError && error.response?.status === 401) {
+      } else if (
+        error instanceof AxiosError &&
+        error.response?.status === 401
+      ) {
         showError("유효하지 않은 사용자입니다.");
       } else {
         showError("서버 오류가 발생했습니다.");
@@ -90,50 +93,58 @@ const ListCard = ({ product }: ListCardProps) => {
 
   return (
     <>
-      <div className="relative border-2 rounded-lg mb-3">
-        <Image
-          width={150}
-          height={150}
-          src={imageSrc}
-          alt={name}
-          className="aspect-square w-full rounded-lg bg-transparent object-cover group-hover:opacity-75"
-          onError={(e) => {
-            const target = e.target as HTMLImageElement;
-            target.src = "/images/noImg.png";
-          }}
-        />
-        <div className="absolute bottom-0 w-full flex justify-between p-4">
-          <button
-            className="cursor-pointer transition-transform duration-200 hover:scale-110 active:scale-95"
-            onClick={handleWishClick}
-          >
-            <PiHeartBold
-              className={`text-[24px] transition-all duration-300 ${
-                wish ? "text-red-500 scale-110" : "text-black"
-              }`}
+      <div className="flex flex-col items-center ">
+        <div className="relative  w-[250px] h-[250px] rounded-lg mb-3   flex justify-center items-center">
+          <div className="relative rounded-lg mb-3  w-[200px] h-[200px]  ">
+            <Image
+              src={imageSrc}
+              alt={name}
+              fill
+              style={{
+                objectFit: "contain",
+                transform: "scale(0.8)",
+                transformOrigin: "center center",
+              }}
+              className="rounded-lg t"
+              onError={(e) => {
+                const target = e.target as HTMLImageElement;
+                target.src = "/images/noImg.png";
+              }}
             />
-          </button>
-          <button
-            className="cursor-pointer transition-transform duration-200 hover:scale-110 active:scale-95"
-            onClick={handleAddCart}
-          >
-            <PiShoppingCartSimpleBold className="text-[24px]" />
-          </button>
+          </div>
+          <div className="absolute bottom-0 w-full flex justify-between p-5">
+            <button
+              className="cursor-pointer transition-transform duration-200 hover:scale-110 active:scale-95"
+              onClick={handleWishClick}
+            >
+              <PiHeartBold
+                className={`text-[24px] transition-all duration-300 ${
+                  wish ? "text-red-500 scale-110" : "text-black"
+                }`}
+              />
+            </button>
+            <button
+              className="cursor-pointer transition-transform duration-200 hover:scale-110 active:scale-95"
+              onClick={handleAddCart}
+            >
+              <PiShoppingCartSimpleBold className="text-[24px]" />
+            </button>
+          </div>
         </div>
-      </div>
-      <div className="flex justify-center">
-        <div className="flex flex-col items-center">
-          <span className="text-sm font-light text-black">
-            {typeof brand === "string" ? brand : brand?.name || "브랜드명"}
-          </span>
-          <h3 className="text-lg text-center text-gray-700">{name}</h3>
-          <span className="flex flex-raw items-center text-lg font-medium text-[#FF572D]">
-            {price}
-            <span className="text-sm">원</span>
-          </span>
-          <div className="flex flex-raw items-center">
-            <FiStar />
-            <span className="ml-1 text-gray-700">{review}</span>
+        <div className="flex justify-center">
+          <div className="flex flex-col items-center">
+            <span className="text-sm font-light text-black">
+              {typeof brand === "string" ? brand : brand?.name || "브랜드명"}
+            </span>
+            <h3 className="text-lg text-center text-gray-700">{name}</h3>
+            <span className="flex flex-raw items-center text-lg font-medium text-[#FF572D]">
+              {price}
+              <span className="text-sm">원</span>
+            </span>
+            <div className="flex flex-raw items-center">
+              <FiStar />
+              <span className="ml-1 text-gray-700">{review}</span>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 🔍 어떤 작업인가요?

- product 카테고리별 페이지 보더 삭제 및 사이즈 조정

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 로그/주석/디버깅 코드가 없나요?
- [ ] 변경된 사항을 문서화했나요? (해당 시)
- [X] 로컬에서 정상 동작 확인했나요?
- [ ] 리뷰어가 알아야 할 내용을 PR 설명에 충분히 적었나요?

---

## 📝 변경사항 요약

- product 카테고리별 페이지 보더 삭제 및 사이즈 조정

---

## 📸 스크린샷 (선택)

<img width="2522" height="1576" alt="image" src="https://github.com/user-attachments/assets/836d467e-dfed-415c-836c-9cba824a4da1" />

<img width="832" height="471" alt="image" src="https://github.com/user-attachments/assets/9dce43a5-da85-42bd-8635-dd76c906c253" />

---

## 🔗 관련 이슈

- Closes #이슈번호
- 관련: #다른이슈

---

## 💬 기타 코멘트

- (리뷰어에게 하고 싶은 말이나 추가 설명)
