### PR TITLE
fix: BrandSection에서 브랜드 이름 표시를 위한 텍스트 제거

### DIFF
--- a/src/components/landing/BrandSection.tsx
+++ b/src/components/landing/BrandSection.tsx
@@ -63,9 +63,6 @@ const BrandSection: React.FC<BrandSectionProps> = ({ id, brands }) => {
             }}
             className="bg-white"
           />
-          <div className="absolute z-40 top-[50%] left-[50%] items-center translate-x-[-50%] text-white text-lg md:text-2xl font-medium">
-            {selectedBrand.products?.[0]?.brand?.name || "브랜드 이름"}
-          </div>
           {/* Overlay 마스킹  */}
           <div className="absolute inset-0 bg-black opacity-5"></div>
         </div>


### PR DESCRIPTION
## 🔍 어떤 작업인가요?

- 브랜드 사진 변경 후 브랜드 탭 사진 위에 있는 브랜드 이름 삭제 

---

## ✅ 체크리스트

- [ ] 코드에 불필요한 로그/주석/디버깅 코드가 없나요?
- [ ] 변경된 사항을 문서화했나요? (해당 시)
- [X] 로컬에서 정상 동작 확인했나요?
- [ ] 리뷰어가 알아야 할 내용을 PR 설명에 충분히 적었나요?

---

## 📝 변경사항 요약

- 브랜드 이름 띄우는 부분 코드 삭제 
---

## 📸 스크린샷 (선택)

<img width="1227" height="509" alt="스크린샷 2025-08-14 오후 2 46 14" src="https://github.com/user-attachments/assets/b96d9c17-0cc5-430c-b0b8-5fb580bb3c33" />


---

## 🔗 관련 이슈

- Closes #이슈번호
- 관련: #다른이슈

---

## 💬 기타 코멘트

- (리뷰어에게 하고 싶은 말이나 추가 설명)
